### PR TITLE
Pi connection fixes

### DIFF
--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -316,7 +316,18 @@ var PiSelectorPanel = function(options) {
     //      
     this.simulateRunProgramState = function(piName, piPath, datasetLocation){
         //add pi to list and select it
-        $('<option />', {value: piName, text: piName}).appendTo(deviceDropDownMenu);
+        isPresent = false;
+        for(i=0; i<deviceDropDownMenu.options.length;i++){
+            if(deviceDropDownMenu.options[i].value == piName){
+                isPresent = true;
+                break;
+            }
+        }
+        if(!isPresent){
+            piMenuDataPrevious[piName] = piName;
+            $('<option />', {value: piName, text: piName}).appendTo(deviceDropDownMenu);
+        }
+        
         deviceDropDownMenu.val(piName);
         
         //set the state of the run button

--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -9,15 +9,14 @@ var PiSelectorPanel = function(options) {
     
     var _this = this;
     
-    var selectdataPrevious = {};
-    var selectdata = {};
+    var piMenuDataPrevious = {};
+    var piMenuData = {};
 
     //
     // Stored vals for when we stop the recording
     //    
     var currentlyRecording = false;
     var currentlySelectedPi;
-    var reselectPi;
     var currentRecordingLocation;
     var currentControllerPath;
     var currentControllerName;
@@ -31,7 +30,7 @@ var PiSelectorPanel = function(options) {
     //
     //function to determine if a pi is online or offline
     //      
-    this.isPiOffline = function(piName){    
+    this.isPiOffline = function(piName){
         var retval = false;
         //if we have no list of pis chances are we haven't received a response from the server
         if(this.availableControllers.length == 0){
@@ -79,31 +78,34 @@ var PiSelectorPanel = function(options) {
             }
         }        
     }
+    
+        
+    //
+    // set default state of topbar program controls UI
+    //    
+    this.setProgramControlsToNeutral = function() {
+        runProgramButton.html('<span class="glyphicon glyphicon-play"></span><span class="deviceRunButtonText">run program</span>');
+        runProgramButton.removeClass("rungreen");
+        runProgramButton.removeClass("stopred");
+        runProgramButton.prop("disabled", true);
+        deviceDropDownMenu.prop("disabled", false);     
+        var contents = $('#program-editor-recordingstatus').text("Connected to ");   
+        _this.currentlyRecording = false;        
+        _this.selectedController = null;
+    }
+    
         
     //
     // AJAX call and handler for listing Pis.
     //
-    this.loadPiList = function() {
-        
-        //runProgramButton.text("run program");
-        runProgramButton.html('<span class="glyphicon glyphicon-play"></span><span class="deviceRunButtonText">run program</span>');
-        runProgramButton.removeClass("rungreen");
-        runProgramButton.removeClass("stopred");
-        runProgramButton.prop("disabled", false); 
-        _this.currentlyRecording = false;
-        deviceDropDownMenu.prop("disabled", false);     
-        var contents = $('#program-editor-recordingstatus').text("Connected to ");        
-
+    this.loadPiList = function(rebuildMenu) {
         // console.log("[DEBUG] loadPiList loading...");
-        for (var member in selectdata) delete selectdata[member];
-        selectdata["none"] = "none";
-
+        
+        //clear dropdown menu data and list of available controllers
+        for (var member in piMenuData) delete piMenuData[member];
+        piMenuData["none"] = "none";
         _this.availableControllers = [];
-        _this.selectedController = null;
-
-        runProgramButton.prop("disabled", true);
-        var pisFound = 0;
-
+        
         var url = '/ext/flow/controllers';
 
         $.ajax({
@@ -132,41 +134,34 @@ var PiSelectorPanel = function(options) {
                         if(!controller.online) {
                             continue;
                         }
-
                         if(controller.status.recording_interval != null) {
                             continue;
                         }
-                        
-                         _this.addPiToDataList(i+1, controller.name);//_this.addPiToMenu(i, pisFound, controller.name);
-                        
-                        pisFound++;
-                        
+                        piMenuData[controller.name] = controller.name;
                     }
  
-                    _this.addPisToMenu();    
-                    
-                    if(_this.reselectPi)
-                        _this.reselectPreviousPi();
+                    if(rebuildMenu)
+                        _this.addPisToMenu();  
+                    else
+                        _this.rebuildPiMenuIfNeeded();  
                     
                     _this.updateRunningProgramBlocks();
 
                 } else {
-                  
-                    _this.addPisToMenu();    
-                    
-                    if(_this.reselectPi)
-                        _this.reselectPreviousPi();                    
+                    if(rebuildMenu)    
+                        _this.addPisToMenu();    
+                     else
+                        _this.rebuildPiMenuIfNeeded();
                     
                     console.log("[ERROR] Error listing controllers", response);
                 }
                  
             },
             error: function(data) {
-               
-                _this.addPisToMenu();
-
-                if(_this.reselectPi)
-                    _this.reselectPreviousPi();
+                if(rebuildMenu)
+                    _this.addPisToMenu();
+                else
+                    _this.rebuildPiMenuIfNeeded();  
                 
                 console.log("[ERROR] List controllers error", data);
             },
@@ -174,44 +169,17 @@ var PiSelectorPanel = function(options) {
     };    
     
     //
-    //add an entry for the pi to the data object
-    //
-    this.addPiToDataList = function(index, piname){
-        selectdata[piname] = piname;
-    }
-    
-    
-    //
     //add an entry for the pi to the drop down menu
     //
     this.addPisToMenu = function(){ 
-        //is this the same as the previous list?
-        if(JSON.stringify(selectdata) === JSON.stringify(selectdataPrevious)){
-            //it is, no need to change menu, bail
-            _this.reselectPi = false;
-            
-            //restore UI, we reset UI state when getting list of Pis
-            if(deviceDropDownMenu.val() != "none"){ 
-                runProgramButton.html('<span class="glyphicon glyphicon-play"></span><span class="deviceRunButtonText">run program on ' + deviceDropDownMenu.val() + '</span>');
-                runProgramButton.addClass("rungreen");
-                runProgramButton.removeClass("stopred"); 
-                runProgramButton.prop("disabled", false); 
-            }
-            
-            return;
-        }
-        //delete previous list, something has changed
-        for (var member in selectdataPrevious) delete selectdataPrevious[member];
-        //clear the list
+        //delete previous menu data
+        for (var member in piMenuDataPrevious) delete piMenuDataPrevious[member];
+        //clear the dropdown menu list
         deviceDropDownMenu.empty();
-        //for testing
-        //this.addPiToDataList(10, "RPi001");
-        //this.addPiToDataList(21, "RPi002");
-        //this.addPiToDataList(32, "RPi003");
-        //add new list of entries into the list and store the entries in selectdataPrevious
-        for(var val in selectdata) {
-            selectdataPrevious[val] = val; //set the list of current values for future comparison
-            $('<option />', {value: val, text: selectdata[val]}).appendTo(deviceDropDownMenu);
+        //add new list of entries into the list and store the entries in piMenuDataPrevious
+        for(var val in piMenuData) {
+            piMenuDataPrevious[val] = val; //set the list of current values for future comparison
+            $('<option />', {value: val, text: piMenuData[val]}).appendTo(deviceDropDownMenu);
         }
     }    
 
@@ -220,7 +188,6 @@ var PiSelectorPanel = function(options) {
     //    
     deviceDropDownMenu.change(function() {
         //console.log("[DEBUG] deviceDropDownMenu change " + deviceDropDownMenu.val());
-
         _this.selectPi(deviceDropDownMenu.val());
     });
 
@@ -232,23 +199,30 @@ var PiSelectorPanel = function(options) {
         if(_this.currentlyRecording){
             return;
         }
-        _this.reselectPi = true;
-        //which Pi were we selected on?
+        //which Pi was selected?
         _this.currentlySelectedPi = deviceDropDownMenu.val();
-        
-        _this.loadPiList();
-        
-        //console.log("[DEBUG] focusin ");
+        _this.loadPiList(false);
+       
     }); 
+    
+    //
+    //rebuild pi menu 
+    //
+    this.rebuildPiMenuIfNeeded = function(){ 
+        //is this the same as the previous list?
+        if(JSON.stringify(piMenuData) != JSON.stringify(piMenuDataPrevious)){
+            _this.addPisToMenu();
+            _this.reselectPreviousPi();
+        }
+    }
     
     //
     //reselect the previously selected pi
     //  
     this.reselectPreviousPi = function(){
         var foundPi = false;
-        _this.reselectPi = false;
-        for(var val in selectdata) {
-            if(selectdata[val] == _this.currentlySelectedPi){
+        for(var val in piMenuData) {
+            if(piMenuData[val] == _this.currentlySelectedPi){
                 foundPi = true;
                 deviceDropDownMenu.val(_this.currentlySelectedPi);
                 break;
@@ -266,7 +240,6 @@ var PiSelectorPanel = function(options) {
     this.reselectCurrentPi = function(){
         //console.log("[DEBUG] reselectCurrentPi ");
         _this.selectPi(deviceDropDownMenu.val());
-        
     }
     
     //
@@ -281,7 +254,6 @@ var PiSelectorPanel = function(options) {
         
         //set up everything else in the UI
         //set state of run program button
-        //runProgramButton.text("run program");
         runProgramButton.html('<span class="glyphicon glyphicon-play"></span><span class="deviceRunButtonText">run program</span>');
         runProgramButton.removeClass("rungreen");
         runProgramButton.removeClass("stopred");        
@@ -297,9 +269,8 @@ var PiSelectorPanel = function(options) {
     //
     //function to select no pis from the list
     //      
-    this.selectNoPi = function(){        
+    this.selectNoPi = function(){
         //set state of run program button
-        //runProgramButton.text("run program");
         runProgramButton.html('<span class="glyphicon glyphicon-play"></span><span class="deviceRunButtonText">run program</span>');
         runProgramButton.removeClass("rungreen");
         runProgramButton.removeClass("stopred");        
@@ -311,12 +282,8 @@ var PiSelectorPanel = function(options) {
         clearSubscriptions();
         removeMessageHandlers();
         
-        //
-        // Clear any old sensor data being displayed.
-        // Do this by calling the handler with an empty array of
-        // data.
-        //            
-        editor.getProgramEditorPanel().handleSensorData(null, { data: [] });
+        //handle unselection of pi, clear program editor state
+        editor.getProgramEditorPanel().piUnselected();
                 
     }
     //
@@ -332,13 +299,12 @@ var PiSelectorPanel = function(options) {
         _this.currentlyRecording = false;
 
         //update button
-        //runProgramButton.text("run program on " + _this.currentControllerName);
         runProgramButton.html('<span class="glyphicon glyphicon-play"></span><span class="deviceRunButtonText">run program on ' + _this.currentControllerName + '</span>');
         runProgramButton.addClass("rungreen");
-        runProgramButton.removeClass("stopred");        
+        runProgramButton.removeClass("stopred");
         runProgramButton.prop("disabled", false); 
         //enable drop down
-        deviceDropDownMenu.prop("disabled", false);     
+        deviceDropDownMenu.prop("disabled", false);
         //update connection text
         var contents = $('#program-editor-recordingstatus').text("Connected to ");
         
@@ -350,13 +316,11 @@ var PiSelectorPanel = function(options) {
     //      
     this.simulateRunProgramState = function(piName, piPath, datasetLocation){
         //add pi to list and select it
-        //this.addPiToDataList(999, piName);
         $('<option />', {value: piName, text: piName}).appendTo(deviceDropDownMenu);
         deviceDropDownMenu.val(piName);
         
         //set the state of the run button
         runProgramButton.prop("disabled", false); 
-        //runProgramButton.text("stop program on " + piName);
         runProgramButton.html('<span class="glyphicon glyphicon-stop"></span><span class="deviceRunButtonText">stop program on ' + piName + '</span>');
         runProgramButton.removeClass("rungreen");
         runProgramButton.addClass("stopred");        
@@ -373,7 +337,6 @@ var PiSelectorPanel = function(options) {
                 
         //get messages from the Pi
         this.reselectCurrentPi(); //_this.selectPi(deviceDropDownMenu.val());
-        
     }
     
     
@@ -396,7 +359,6 @@ var PiSelectorPanel = function(options) {
             if(deviceName == this.availableControllers[i].name) { 
             
                 this.selectedController = this.availableControllers[i];
-
                 //
                 // Send message over websocket to request sensor data
                 //
@@ -414,7 +376,7 @@ var PiSelectorPanel = function(options) {
                 console.log("[DEBUG] Requesting sensor data from ", controller.path);
                 
                 if(!_this.currentlyRecording){
-                   runProgramButton.html('<span class="glyphicon glyphicon-play"></span><span class="deviceRunButtonText">run program on ' + controller.name + '</span>');                   
+                   runProgramButton.html('<span class="glyphicon glyphicon-play"></span><span class="deviceRunButtonText">run program on ' + controller.name + '</span>');
                    runProgramButton.addClass("rungreen");
                    runProgramButton.removeClass("stopred");
                     //
@@ -422,7 +384,7 @@ var PiSelectorPanel = function(options) {
                     // Do this by calling the handler with an empty array of
                     // data.
                     //
-                    editor.getProgramEditorPanel().handleSensorData(null, { data: [] });                    
+                    editor.getProgramEditorPanel().handleSensorData(null, { data: [] });
                 }
                 
                 //clear any existing subscriptions
@@ -455,7 +417,7 @@ var PiSelectorPanel = function(options) {
         }
 
         var dsDisplayedName = "";
-		var dsFileName = "";
+        var dsFileName = "";
         var controller = _this.selectedController;
         var programSpec = editor.getProgramSpec();
 
@@ -472,40 +434,40 @@ var PiSelectorPanel = function(options) {
             runProgramButton.html('<span class="glyphicon glyphicon-play"></span><span class="deviceRunButtonText">run program on ' + controller.name + '</span>');
             return;
         }
-		
-		//create a file name for the dataset based on current date and time
-		var d = new Date();
-		var year = d.getFullYear();
-		var month = d.getMonth() + 1;
-		var day = d.getDate();
-		var hour = d.getHours();
-		var min = d.getMinutes();
-		var sec = d.getSeconds();
-		
-		var potentialName = "dataset_" + year;
-		if(month < 10)
-			potentialName = potentialName + "0" + month;
-		else
-			potentialName = potentialName + month;
-		if(day < 10)
-			potentialName = potentialName + "0" + day + "_";
-		else
-			potentialName = potentialName + day + "_";
-		if(hour < 10)
-			potentialName = potentialName + "0" + hour;
-		else
-			potentialName = potentialName + hour;
-		if(min < 10)
-			potentialName = potentialName + "0" + min;
-		else
-			potentialName = potentialName + min;
-		if(sec < 10)
-			potentialName = potentialName + "0" + sec;
-		else
-			potentialName = potentialName + sec;
-		
-		dsFileName = potentialName;
-		
+        
+        //create a file name for the dataset based on current date and time
+        var d = new Date();
+        var year = d.getFullYear();
+        var month = d.getMonth() + 1;
+        var day = d.getDate();
+        var hour = d.getHours();
+        var min = d.getMinutes();
+        var sec = d.getSeconds();
+        
+        var potentialName = "dataset_" + year;
+        if(month < 10)
+            potentialName = potentialName + "0" + month;
+        else
+            potentialName = potentialName + month;
+        if(day < 10)
+            potentialName = potentialName + "0" + day + "_";
+        else
+            potentialName = potentialName + day + "_";
+        if(hour < 10)
+            potentialName = potentialName + "0" + hour;
+        else
+            potentialName = potentialName + hour;
+        if(min < 10)
+            potentialName = potentialName + "0" + min;
+        else
+            potentialName = potentialName + min;
+        if(sec < 10)
+            potentialName = potentialName + "0" + sec;
+        else
+            potentialName = potentialName + sec;
+        
+        dsFileName = potentialName;
+        
 
         //give the dataset a default name in the case where there is no data storage block and we want to create an empty dataset
         var haveDsBlock = editor.getProgramEditorPanel().programHasDataStorageBlock();
@@ -646,8 +608,8 @@ var PiSelectorPanel = function(options) {
         stopDiagram.execute();
     }
     
-
-    this.loadPiList();
+    this.setProgramControlsToNeutral();
+    this.loadPiList(true);
     
     return this;
 }

--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -180,7 +180,7 @@ var PiSelectorPanel = function(options) {
         for(var val in piMenuData) {
             piMenuDataPrevious[val] = val; //set the list of current values for future comparison
             $('<option />', {value: val, text: piMenuData[val]}).appendTo(deviceDropDownMenu);
-        }
+        }        
     }    
 
     //
@@ -316,17 +316,10 @@ var PiSelectorPanel = function(options) {
     //      
     this.simulateRunProgramState = function(piName, piPath, datasetLocation){
         //add pi to list and select it
-        isPresent = false;
-        for(i=0; i<deviceDropDownMenu.options.length;i++){
-            if(deviceDropDownMenu.options[i].value == piName){
-                isPresent = true;
-                break;
-            }
-        }
-        if(!isPresent){
+        if ( $("#program-editor-devicemenuselect option[value=" + piName + "]").length == 0 ){
             piMenuDataPrevious[piName] = piName;
             $('<option />', {value: piName, text: piName}).appendTo(deviceDropDownMenu);
-        }
+        }        
         
         deviceDropDownMenu.val(piName);
         

--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -1462,7 +1462,9 @@ var ProgramEditorPanel = function(options) {
     //update blocks when pi is unselected
     //    
     this.piUnselected = function (){
+        //
         // Clear any old sensor data being displayed.
+        // Do this by calling the handler with an empty array of
         // data.
         //            
         _this.handleSensorData(null, { data: [] });

--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -47,7 +47,7 @@ var ProgramEditorPanel = function(options) {
     
     //recording/running program
     var m_runningProgram = false;
-
+    
     //
     // Return current diagram
     //
@@ -1459,6 +1459,16 @@ var ProgramEditorPanel = function(options) {
     }    
 
     //
+    //update blocks when pi is unselected
+    //    
+    this.piUnselected = function (){
+        // Clear any old sensor data being displayed.
+        // data.
+        //            
+        _this.handleSensorData(null, { data: [] });
+    }
+
+    //
     // Handle sensor data messages
     //
     this.handleSensorData = function(timestamp, params) {
@@ -1482,9 +1492,9 @@ var ProgramEditorPanel = function(options) {
             // Check for device blocks for which we did not receive any data
             // and set their values to null.
             //
-			if(_this.m_diagram == null){
-				return;
-			}
+            if(_this.m_diagram == null){
+                return;
+            }
             for (var i = 0; i < _this.m_diagram.blocks.length; i++) {
                 var block = _this.m_diagram.blocks[i];
                 if(_this.isDeviceBlock(block.type)) {

--- a/static/flow/views/program-editor-view.js
+++ b/static/flow/views/program-editor-view.js
@@ -110,7 +110,7 @@ var ProgramEditorView = function(options) {
      deviceStatus.appendTo(deviceHolder);            
      var deviceMenuHolder  = jQuery('<span>', {class:'deviceMenuHolder'} );
      deviceMenuHolder.appendTo(deviceHolder);     
-     var deviceSelect = $('<select />', {class:'deviceMenuSelect'} );
+     var deviceSelect = $('<select />', {id: 'program-editor-devicemenuselect', class:'deviceMenuSelect'} );
      
       //program start button
      var devicerunHolder  = jQuery('<span>', {class:'deviceRunHolder'} );
@@ -275,6 +275,8 @@ var ProgramEditorView = function(options) {
     //
     base.loadProgramFromSpec = function(params) {
         // console.log("[DEBUG] ProgramEditorView loadProgramFromSpec()", params);
+        var filename    = params.filename;
+        var displayedName    = params.displayedName;
 
         programloaded = true;
         
@@ -282,7 +284,7 @@ var ProgramEditorView = function(options) {
         
         var nameWidget      = jQuery('#program-editor-filename');
 
-        nameWidget.val(programSpec.name);
+        nameWidget.val(displayedName);
         
         //piSelectorPanel.loadPiList(); 
         piSelectorPanel.exitRunProgramState();

--- a/static/flow/views/program-editor-view.js
+++ b/static/flow/views/program-editor-view.js
@@ -310,7 +310,8 @@ var ProgramEditorView = function(options) {
 
         nameWidget.val('');
         
-        piSelectorPanel.loadPiList();
+        piSelectorPanel.setProgramControlsToNeutral();
+        piSelectorPanel.loadPiList(true);
         piSelectorPanel.exitRunProgramState();
         piSelectorPanel.resetPiSelectionState();
         

--- a/static/flow/views/program-editor-view.js
+++ b/static/flow/views/program-editor-view.js
@@ -284,7 +284,7 @@ var ProgramEditorView = function(options) {
         
         var nameWidget      = jQuery('#program-editor-filename');
 
-        nameWidget.val(displayedName);
+        nameWidget.val(programSpec.name);
         
         //piSelectorPanel.loadPiList(); 
         piSelectorPanel.exitRunProgramState();


### PR DESCRIPTION
pi-selector-panel.js was due for clean-up.  Clean-up might have been better placed in a tech-debt branch, but naming conventions and excess code were throwing me off as I hunted for pi connection bugs so I did some housekeeping.  I removed whitespace, refactored code, and removed obsolete comments.  
More important are the changes related to problems with the pi connection drop down menu and pi connection troubles.  Changes in simulateRunProgramState() prevent duplicate entry of Pi name in dropdown menu.  Restructure of loadPiList() and addPisToMenu() fix issues caused when we tried to reload the Pi list on deviceDropDownMenu focusin event - we were losing the reference to the currently selected Pi.  We need to keep the list up to date, but can be less aggressive about resetting variables and rebuilding the menu. 