### PR TITLE
158484929 saved program wrong internal

### DIFF
--- a/static/flow/views/landing-page-data-set-view.js
+++ b/static/flow/views/landing-page-data-set-view.js
@@ -202,8 +202,8 @@ var LandingPageDataSetView = function(options) {
 		else
 			displayedFilename = item.name;
         var controllername = metadata.controller_name;
-        var programdata = metadata.program;
-        var programname = programdata.name;
+        var programData = metadata.program;
+        var programName = programData.displayedName;
         var isEmpty = false;
         if(metadata.is_empty && metadata.is_empty == true)
             isEmpty = true;
@@ -236,7 +236,7 @@ var LandingPageDataSetView = function(options) {
         
         var livedataitemboxprogram  = jQuery('<div>', {class:'liveDataItemBox concordblue'} );
         var livedataitemboxprogramtitle  = jQuery('<div>', {class:'liveDataItemBoxTitle', text:"running program"} );
-        var livedataitemboxprogramname  = jQuery('<div>', {class:'liveDataItemBoxName', text:programname} );
+        var livedataitemboxprogramname  = jQuery('<div>', {class:'liveDataItemBoxName', text:programName} );
         var viewProgramButton = $('<button>', { class:'liveDataItemBoxButton',   html: 'view program' } );
         livedataitemboxprogramtitle.appendTo(livedataitemboxprogram);   
         livedataitemboxprogramname.appendTo(livedataitemboxprogram);   
@@ -245,7 +245,7 @@ var LandingPageDataSetView = function(options) {
         viewProgramButton.click(item, function(e) {
             console.log("[DEBUG] viewProgramButton click", e.data);
             var editor = getTopLevelView('program-editor-view');
-            editor.loadProgramFromSpec({programdata: programdata});
+            editor.loadProgramFromSpec({programdata: programData});
             
             var piSelectorPanel = editor.getPiSelectorPanel();
             piSelectorPanel.simulateRunProgramState(metadata.controller_name, metadata.controller_path, metadata.recording_location);

--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -516,13 +516,15 @@ var PiSelectorPanel = function(options) {
         //
         // Set name on program
         //
-        var name = jQuery('#program-editor-filename').val();
+        var displayedName = jQuery('#program-editor-filename').val();
         //var name = editor.getFileManager().getProgramName();
-        programSpec.name = name;
+        programSpec.name = ""; //don't have an actual folder location for this "virtual" program
+        programSpec.archived = false;
+        programSpec.displayedName = displayedName;
         //console.log("[DEBUG] Set name: " + programSpec.name);
 
-        if(!programSpec.name || programSpec.name == '') {
-            alert("No name set on program. " + programSpec.name);
+        if(!programSpec.displayedName || programSpec.displayedName == '') {
+            alert("No name set on program. " + programSpec.displayedName);
             runProgramButton.prop("disabled", false); 
             runProgramButton.html('<span class="glyphicon glyphicon-play"></span><span class="deviceRunButtonText">run program on ' + controller.name + '</span>');                        
             return;

--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -84,7 +84,7 @@ var ProgramEditorPanel = function(options) {
             programSpec.displayedName = "untitled program";
             programSpec.archived = false;
         }
-        else if(programSpec.name = "")
+        else if(programSpec.name = ""){
             // if we loaded a program copy stored in dataset metadata, 
             // then it might not have a valid file name
             programSpec.name = this.chooseProgramName();

--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -84,8 +84,9 @@ var ProgramEditorPanel = function(options) {
             programSpec.displayedName = "untitled program";
             programSpec.archived = false;
         }
-        else if(programSpec.name == ""){
-            // if we loaded a program copy stored in dataset metadata, 
+        else if(programSpec.name == null || programSpec.name == ""){
+            // if we loaded a program copy stored in dataset metadata,
+            // or if the name value is null or undefined
             // then it might not have a valid file name
             programSpec.name = this.chooseProgramName();
         }

--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -84,7 +84,7 @@ var ProgramEditorPanel = function(options) {
             programSpec.displayedName = "untitled program";
             programSpec.archived = false;
         }
-        else if(programSpec.name = ""){
+        else if(programSpec.name == ""){
             // if we loaded a program copy stored in dataset metadata, 
             // then it might not have a valid file name
             programSpec.name = this.chooseProgramName();

--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -82,6 +82,12 @@ var ProgramEditorPanel = function(options) {
             programSpec = { blocks: [] };
             programSpec.name = this.chooseProgramName();
             programSpec.displayedName = "untitled program";
+            programSpec.archived = false;
+        }
+        else if(programSpec.name = "")
+            // if we loaded a program copy stored in dataset metadata, 
+            // then it might not have a valid file name
+            programSpec.name = this.chooseProgramName();
         }
 
         //

--- a/static/flow/views/program-editor-view.js
+++ b/static/flow/views/program-editor-view.js
@@ -275,16 +275,15 @@ var ProgramEditorView = function(options) {
     //
     base.loadProgramFromSpec = function(params) {
         // console.log("[DEBUG] ProgramEditorView loadProgramFromSpec()", params);
-        var filename    = params.filename;
-        var displayedName    = params.displayedName;
-
         programloaded = true;
         
         var programSpec = params.programdata;
+        var filename    = programSpec.name;
+        var displayedName    = programSpec.displayedName;
         
         var nameWidget      = jQuery('#program-editor-filename');
 
-        nameWidget.val(programSpec.name);
+        nameWidget.val(displayedName);
         
         //piSelectorPanel.loadPiList(); 
         piSelectorPanel.exitRunProgramState();


### PR DESCRIPTION
Handle fileIO workflow case where user loads and resaves a program stored in a dataset's metadata.  In this case, the program does not have an internal file name and is not previously stored on the server (only exists as a representation within the dataset metadata).  Ensure that we define program spec correctly and give program an internal date/time name in this case.