### PR TITLE
create new internal program name when opening old, legacy programs

### DIFF
--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -83,6 +83,12 @@ var ProgramEditorPanel = function(options) {
             programSpec.name = this.chooseProgramName();
             programSpec.displayedName = "untitled program";
         }
+        else if(programSpec.name == null || programSpec.name == ""){
+            // if we loaded a program copy stored in dataset metadata,
+            // or if the name value is null or undefined
+            // then it might not have a valid file name
+            programSpec.name = this.createDateTimeName("program_");
+        }
 
         //
         // bind zoom menu/function to keyboard keys, WIP: need to potentially hook this back up

--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -87,7 +87,7 @@ var ProgramEditorPanel = function(options) {
             // if we loaded a program copy stored in dataset metadata,
             // or if the name value is null or undefined
             // then it might not have a valid file name
-            programSpec.name = this.createDateTimeName("program_");
+            programSpec.name = this.chooseProgramName();
         }
 
         //


### PR DESCRIPTION
[#158746018]
Legacy programs (programSpec.name == null) need to have an internal program name created when they are opened to ensure that they can be saved using the modern internal file structure.