### PR TITLE
get correct attributes when exporting to CODAP

### DIFF
--- a/static/flow/views/data-set-view.js
+++ b/static/flow/views/data-set-view.js
@@ -488,19 +488,14 @@ var DataSetView = function(options) {
         var dataPairs = base.m_plotHandler.plotter.dataPairs;
         if (dataPairs.length && dataPairs[0].xData.data.length) {
 
-            var diagram = base.m_program;
-
             // set collection attributes based on current input blocks
             var attrs = [{name: 'seconds', type: 'numeric', precision: 2}, {name: 'timestamp', type: 'date'}];
-            for (var i = 0; i < diagram.blocks.length; i++) {
-                var block = diagram.blocks[i];
-                if (block.inputCount === 0) {
-                    attrs.push({
-                        name: block.name,
-                        type: 'numeric',
-                        precision: 2,
-                    });
-                }
+            for (var i = 0; i < dataPairs.length; i++) {
+                attrs.push({
+                    name: dataPairs[i].yData.name,
+                    type: 'numeric',
+                    precision: 2,
+                });
             }
 
             CodapTest.prepCollection(

--- a/static/flow/views/data-set-view.js
+++ b/static/flow/views/data-set-view.js
@@ -488,7 +488,7 @@ var DataSetView = function(options) {
         var dataPairs = base.m_plotHandler.plotter.dataPairs;
         if (dataPairs.length && dataPairs[0].xData.data.length) {
 
-            // set collection attributes based on current input blocks
+            // set collection attributes based on sequence data
             var attrs = [{name: 'seconds', type: 'numeric', precision: 2}, {name: 'timestamp', type: 'date'}];
             for (var i = 0; i < dataPairs.length; i++) {
                 attrs.push({


### PR DESCRIPTION
[#158847341]
Old model searched blocks in diagram to determine which blocks were stored as sequences.  New model allows user to connect any block to data storage block so sequence is saved.  To ensure correct attributes are sent to CODAP, get attribute info from the actual loaded dataPair which will be exported to CODAP (rather than parsing it out of program).