### PR TITLE
Display correct dataset name when prompting user to delete

### DIFF
--- a/static/flow/views/landing-page-data-set-view.js
+++ b/static/flow/views/landing-page-data-set-view.js
@@ -363,8 +363,14 @@ var LandingPageDataSetView = function(options) {
     // Delete dataset, this version marks metadata as archived
     //
     var deleteDataset = function(e) {
-        var name = e.data.datasetname;
         var metadata = e.data.metadata;
+        var name;
+        if(metadata == null || metadata.displayedName == null){
+            name = e.data.datasetname;
+        }
+        else{
+            name = metadata.displayedName
+        }
         
         var conf = confirm("Are you sure you want to delete dataset " + name + "?");
 


### PR DESCRIPTION
[#158991159]
Another issue where there is confusion between the displayedName and the old file name.  Be sure to support legacy and modern datasets.