### PR TITLE
use proper controller info when stopping program

### DIFF
--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -676,12 +676,22 @@ var PiSelectorPanel = function(options) {
     //
     this.stopRecording = function(refreshCallback, recordingLocation, controllerPath) {
     
-        if(recordingLocation != null)
-            _this.currentRecordingLocation = recordingLocation;
-        if(controllerPath != null)
-            _this.currentControllerPath = controllerPath;
+        var stopRecordingLocation = _this.currentRecordingLocation;
+        var stopControllerPath = _this.currentControllerPath;
+        var resetDeviceControls = true;
+        
+        //typically stop program via controller information currently configured in the editor
+        //if user request to stop program from some other dataflow component (activity feed, dataview)
+        //be sure to use controller information from function params and maintain editor UI state
+        if(recordingLocation != null && controllerPath != null){
+            stopRecordingLocation = recordingLocation;
+            stopControllerPath = controllerPath;
+            if(stopControllerPath != _this.currentControllerPath){
+                resetDeviceControls = false;
+            }
+        }
 
-        console.log("[DEBUG] Stopping program", _this.currentRecordingLocation);
+        console.log("[DEBUG] Stopping program", stopRecordingLocation);
         
         //
         // Send message over websocket and handle response
@@ -689,25 +699,28 @@ var PiSelectorPanel = function(options) {
         var execParams = {  
                 message_type:   'stop_diagram',
                 message_params: { 
-                    stop_location: _this.currentRecordingLocation },
-                    target_folder:  _this.currentControllerPath,
-                    src_folder:     _this.currentControllerPath,
+                    stop_location: stopRecordingLocation },
+                    target_folder:  stopControllerPath,
+                    src_folder:     stopControllerPath,
                     response_func:  function(ts, params) {
                     if(params.success) {
                         modalAlert({title: 'Stop Program', message: 'Program stopped', nextFunc: function() {
                             if(typeof refreshCallback === "function")
                                 refreshCallback();
-                            
-                            exitRunProgramState();
-                            reselectCurrentPi(); 
+                            if(resetDeviceControls){
+                                exitRunProgramState();
+                                reselectCurrentPi(); 
+                            }
                         }});                        
                     } else {
-                        //failed to stop, restore stop button
-                        runProgramButton.html('stop');
-                        runProgramButton.prop("disabled", false); 
-                        runProgramButton.removeClass("button-disabled noHover");
-                        viewDataButton.prop("disabled", false); 
-                        viewDataButton.removeClass("button-disabled noHover");        
+                        if(resetDeviceControls){
+                            //failed to stop, restore stop button
+                            runProgramButton.html('stop');
+                            runProgramButton.prop("disabled", false); 
+                            runProgramButton.removeClass("button-disabled noHover");
+                            viewDataButton.prop("disabled", false); 
+                            viewDataButton.removeClass("button-disabled noHover");   
+                        }                        
             
                         modalAlert({
                             title: 'Program Stop Error', 

--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -675,13 +675,13 @@ var PiSelectorPanel = function(options) {
     // Stop recording
     //
     this.stopRecording = function(refreshCallback, recordingLocation, controllerPath) {
-
-        console.log("[DEBUG] Stopping program", _this.currentRecordingLocation);
     
         if(recordingLocation != null)
             _this.currentRecordingLocation = recordingLocation;
         if(controllerPath != null)
             _this.currentControllerPath = controllerPath;
+
+        console.log("[DEBUG] Stopping program", _this.currentRecordingLocation);
         
         //
         // Send message over websocket and handle response

--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -678,9 +678,9 @@ var PiSelectorPanel = function(options) {
 
         console.log("[DEBUG] Stopping program", _this.currentRecordingLocation);
     
-        if(_this.currentRecordingLocation == null)
+        if(recordingLocation != null)
             _this.currentRecordingLocation = recordingLocation;
-        if(_this.currentControllerPath == null)
+        if(controllerPath != null)
             _this.currentControllerPath = controllerPath;
         
         //


### PR DESCRIPTION
If caller provides device information when stopping program, always use it.  Otherwise, call back on the last used values.  Allows us to stop program from the editor stop button or from some external caller/program space (like the activity feed stop button).
[#159178473]