### PR TITLE
159281049 add full screen button dataflow

### DIFF
--- a/ext.py
+++ b/ext.py
@@ -98,6 +98,7 @@ def flow_app():
     return flow_extension.render_template('flow-app.html',
         controllers_json = json.dumps(controller_infos),
         use_codap = (request.args.get('use_codap', 0) or request.args.get('codap', 0)),
+        use_fullscreen = (request.args.get('fullscreen', 0)),
         flow_user               = json.dumps(flow_user),
         rhizo_server_version    = rhizo_server_version,
         flow_server_version     = flow_server_version
@@ -221,41 +222,41 @@ def file_operation(operation, type):
                 path = '%s/%s/%s/%s/%s/metadata' % (org_name, 'student-folders', username, type, filename)
             else:
                 path = '%s/%s/%s/%s/%s' % (org_name, 'student-folders', username, type, filename)
-        elif type == 'datasetmeta':	
-            path = '%s/%s/%s/%s/%s' % (org_name, 'student-folders', username, 'datasets', filename)		
-        elif type == 'programmeta':	
-            path = '%s/%s/%s/%s/%s' % (org_name, 'student-folders', username, 'programs', filename)					
+        elif type == 'datasetmeta': 
+            path = '%s/%s/%s/%s/%s' % (org_name, 'student-folders', username, 'datasets', filename)     
+        elif type == 'programmeta': 
+            path = '%s/%s/%s/%s/%s' % (org_name, 'student-folders', username, 'programs', filename)                 
         else:
-			
+            
             path = '%s/%s/%s/%s/%s' % (org_name, 'student-folders', username, type, filename)
 
     #
     # Save op
     #
     def _save():
-		if type == 'programmeta' or type == 'datasetmeta':
-			contentmetadata = request.values.get('metadata').encode('utf-8')
-			now         = datetime.datetime.now()
-			pathm = '%s/%s' % (path, 'metadata')
-			resourcem    = _create_file(pathm, now, now, contentmetadata)
-			return json.dumps({
-						'success': True,
-						'message': 'Saved file metadata %s.' % (pathm)
-					})
+        if type == 'programmeta' or type == 'datasetmeta':
+            contentmetadata = request.values.get('metadata').encode('utf-8')
+            now         = datetime.datetime.now()
+            pathm = '%s/%s' % (path, 'metadata')
+            resourcem    = _create_file(pathm, now, now, contentmetadata)
+            return json.dumps({
+                        'success': True,
+                        'message': 'Saved file metadata %s.' % (pathm)
+                    })
 
-		else:
-			content     = request.values.get('content').encode('utf-8')
-			contentmetadata = request.values.get('metadata').encode('utf-8')
-			now         = datetime.datetime.now()
-			_create_folders(path)
-			pathp = '%s/%s' % (path, 'program')
-			pathm = '%s/%s' % (path, 'metadata')
-			resourcep    = _create_file(pathp, now, now, content)
-			resourcem    = _create_file(pathm, now, now, contentmetadata)
-			return json.dumps({
-						'success': True,
-						'message': 'Saved file %s.' % (filename)
-					})
+        else:
+            content     = request.values.get('content').encode('utf-8')
+            contentmetadata = request.values.get('metadata').encode('utf-8')
+            now         = datetime.datetime.now()
+            _create_folders(path)
+            pathp = '%s/%s' % (path, 'program')
+            pathm = '%s/%s' % (path, 'metadata')
+            resourcep    = _create_file(pathp, now, now, content)
+            resourcem    = _create_file(pathm, now, now, contentmetadata)
+            return json.dumps({
+                        'success': True,
+                        'message': 'Saved file %s.' % (filename)
+                    })
 
     #
     # Load op
@@ -297,8 +298,8 @@ def file_operation(operation, type):
     def _list():
         resource    = find_resource(path)
         children    = Resource.query.filter(Resource.parent_id == resource.id, Resource.deleted == False)
-        items = []		
-		
+        items = []      
+        
         for child in children:
             metadata = None
 
@@ -353,14 +354,14 @@ def file_operation(operation, type):
 @app.route('/ext/flow/save_program', methods=['POST'])
 def save_program():
     return file_operation('save', 'programs')
-	
+    
 #
 # API for saving a program metadata to the rhizo-server
 #
 @app.route('/ext/flow/save_program_metadata', methods=['POST'])
 def save_program_metadata():
     return file_operation('save', 'programmeta')
-	
+    
 #
 # API for loading (retrieving the contents of) a program 
 # from the rhizo-server
@@ -410,16 +411,16 @@ def delete_dataset():
 #
 @app.route('/ext/flow/save_dataset_metadata', methods=['POST'])
 def save_dataset_metadata():
-    return file_operation('save', 'datasetmeta')	
+    return file_operation('save', 'datasetmeta')    
 
 #
 # API for listing dataset sequences saved on the rhizo-server
 #
 @app.route('/ext/flow/list_datasetsequences', methods=['POST'])
 def list_datasetsequences():
-    return file_operation('list', 'sequences')	
+    return file_operation('list', 'sequences')  
 
-	
+    
 #
 # Create portal oauth service
 #

--- a/static/flow/flow-app.js
+++ b/static/flow/flow-app.js
@@ -12,6 +12,9 @@ function initFlowApp() {
 
     // showTopLevelView('landing-page-view');
     showTopLevelView('login-page-view');
+    if(g_fullscreen) {
+        var fullscreenWidget = FullScreenWidget();
+    }
 }
 
 //
@@ -92,19 +95,19 @@ function showAdminView() {
 
 // change screens within the app: show the flow diagram editor screen
 function showDiagramEditor() {
-	initDiagramEditor();
-	$('#controllerSelectorPanel').hide();
-	$('#controllerViewerPanel').hide();
-	$('#diagramEditorPanel').show();
-	$('#plotterPanel').hide();
+    initDiagramEditor();
+    $('#controllerSelectorPanel').hide();
+    $('#controllerViewerPanel').hide();
+    $('#diagramEditorPanel').show();
+    $('#plotterPanel').hide();
 }
 
 
 // change screens within the app: show the plotter screen
 function showPlotter() {
-	initPlotter();
-	$('#controllerSelectorPanel').hide();
-	$('#controllerViewerPanel').hide();
-	$('#diagramEditorPanel').hide();
-	$('#plotterPanel').show();
+    initPlotter();
+    $('#controllerSelectorPanel').hide();
+    $('#controllerViewerPanel').hide();
+    $('#diagramEditorPanel').hide();
+    $('#plotterPanel').show();
 }

--- a/static/flow/flow-app.js
+++ b/static/flow/flow-app.js
@@ -13,7 +13,7 @@ function initFlowApp() {
     // showTopLevelView('landing-page-view');
     showTopLevelView('login-page-view');
     if(g_fullscreen) {
-        var fullscreenWidget = FullScreenWidget();
+        FullScreenWidget();
     }
 }
 

--- a/static/flow/images/fullscreen-exit.svg
+++ b/static/flow/images/fullscreen-exit.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="20px" height="20px" viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve">
+<g id="Layer_1">
+	<g>
+		<polyline fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" points="18,14 13,14
+			13,19 		"/>
+		<line fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" x1="13" y1="13" x2="17" y2="18"/>
+		<polyline fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" points="7,19 7,14
+			2,14 		"/>
+		<line fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" x1="7" y1="14" x2="3" y2="18"/>
+		<polyline fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" points="2,8 7,8
+			7,3 		"/>
+		<line fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" x1="7" y1="8" x2="3" y2="4"/>
+		<polyline fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" points="13,3 13,8
+			18,8 		"/>
+		<line fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" x1="13" y1="8" x2="17" y2="4"/>
+	</g>
+</g>
+</svg>

--- a/static/flow/images/fullscreen.svg
+++ b/static/flow/images/fullscreen.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="20px" height="20px" viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve">
+<g id="Layer_1">
+	<g>
+		<polyline fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" points="8,4 3,4
+			3,9 		"/>
+		<line fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" x1="3" y1="3" x2="7" y2="8"/>
+		<polyline fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" points="17,9 17,4
+			12,4 		"/>
+		<line fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" x1="17" y1="4" x2="13" y2="8"/>
+		<polyline fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" points="12,18 17,18
+			17,13 		"/>
+		<line fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" x1="17" y1="18" x2="13" y2="14"/>
+		<polyline fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" points="3,13 3,18
+			8,18 		"/>
+		<line fill="none" stroke="#6f5635" stroke-width="2" stroke-miterlimit="10" x1="3" y1="18" x2="7" y2="14"/>
+	</g>
+</g>
+</svg>

--- a/static/flow/style.css
+++ b/static/flow/style.css
@@ -824,6 +824,32 @@ button.filter {
 }
 
 /*
+* — fullscreen —
+*/
+.fullscreen-container {
+    position:absolute;
+    bottom:0;
+    right:0;
+}
+#fullscreen-button {
+  margin: 5px;
+  width: 42px;
+  height: 42px;
+  background: no-repeat url(./images/fullscreen.svg) center/100%;
+  cursor: pointer;
+  border-radius: 5px;
+}
+
+#fullscreen-button:hover {
+  background-size: 105%;
+  box-shadow: 0 0 2px #D09845;
+}
+
+#fullscreen-button.exit {
+  background: no-repeat url(./images/fullscreen-exit.svg) center/100%;
+}
+
+/*
 * — Colors —
 */
 .concordgreen {

--- a/static/flow/style.css
+++ b/static/flow/style.css
@@ -827,9 +827,9 @@ button.filter {
 * — fullscreen —
 */
 .fullscreen-container {
-    position:absolute;
-    bottom:0;
-    right:0;
+    position: fixed;
+    bottom: 0;
+    right: 0;
 }
 #fullscreen-button {
   margin: 5px;

--- a/static/flow/views/fullscreen-widget.js
+++ b/static/flow/views/fullscreen-widget.js
@@ -1,0 +1,57 @@
+//
+// A widget to make app fullscreen
+//
+var FullScreenWidget = function() {
+
+    //var fullscreenContainer = jQuery('<div>', {class:'fullscreen-container'} );
+    var fullscreenContainer = jQuery('#fullscreen-widget');
+    var fullscreenButton  = jQuery('<div>', {id:'fullscreen-button'} );
+    fullscreenButton.appendTo(fullscreenContainer);
+    //fullscreenContainer.appendTo(menuAndContentHolder);
+    var fullscreen = false;
+    fullscreenButton.click(function(e) {
+        if (screenfull.enabled) {
+            screenfull.toggle();
+        }
+    });
+    function requestFullScreen(element) {
+        // Supports most browsers and their versions.
+        var requestMethod = element.requestFullScreen || element.webkitRequestFullScreen || element.mozRequestFullScreen || element.msRequestFullScreen;
+
+        if (requestMethod) { // Native full screen.
+            requestMethod.call(element);
+        } else if (typeof window.ActiveXObject !== "undefined") { // Older IE.
+            var wscript = new ActiveXObject("WScript.Shell");
+            if (wscript !== null) {
+                wscript.SendKeys("{F11}");
+            }
+        }
+
+        fullscreen = !fullscreen;
+        if(fullscreen){
+            $('#fullscreen-button').addClass("exit");
+        }
+        else{
+            $('#fullscreen-button').removeClass("exit");
+        }
+    }
+
+    /*!
+    * screenfull
+    * v3.3.2 - 2017-10-27
+    * (c) Sindre Sorhus; MIT License
+    */
+
+    !function(){"use strict";var a="undefined"!=typeof window&&void 0!==window.document?window.document:{},b="undefined"!=typeof module&&module.exports,c="undefined"!=typeof Element&&"ALLOW_KEYBOARD_INPUT"in Element,d=function(){for(var b,c=[["requestFullscreen","exitFullscreen","fullscreenElement","fullscreenEnabled","fullscreenchange","fullscreenerror"],["webkitRequestFullscreen","webkitExitFullscreen","webkitFullscreenElement","webkitFullscreenEnabled","webkitfullscreenchange","webkitfullscreenerror"],["webkitRequestFullScreen","webkitCancelFullScreen","webkitCurrentFullScreenElement","webkitCancelFullScreen","webkitfullscreenchange","webkitfullscreenerror"],["mozRequestFullScreen","mozCancelFullScreen","mozFullScreenElement","mozFullScreenEnabled","mozfullscreenchange","mozfullscreenerror"],["msRequestFullscreen","msExitFullscreen","msFullscreenElement","msFullscreenEnabled","MSFullscreenChange","MSFullscreenError"]],d=0,e=c.length,f={};d<e;d++)if((b=c[d])&&b[1]in a){for(d=0;d<b.length;d++)f[c[0][d]]=b[d];return f}return!1}(),e={change:d.fullscreenchange,error:d.fullscreenerror},f={request:function(b){var e=d.requestFullscreen;b=b||a.documentElement,/ Version\/5\.1(?:\.\d+)? Safari\//.test(navigator.userAgent)?b[e]():b[e](c&&Element.ALLOW_KEYBOARD_INPUT)},exit:function(){a[d.exitFullscreen]()},toggle:function(a){this.isFullscreen?this.exit():this.request(a)},onchange:function(a){this.on("change",a)},onerror:function(a){this.on("error",a)},on:function(b,c){var d=e[b];d&&a.addEventListener(d,c,!1)},off:function(b,c){var d=e[b];d&&a.removeEventListener(d,c,!1)},raw:d};if(!d)return void(b?module.exports=!1:window.screenfull=!1);Object.defineProperties(f,{isFullscreen:{get:function(){return Boolean(a[d.fullscreenElement])}},element:{enumerable:!0,get:function(){return a[d.fullscreenElement]}},enabled:{enumerable:!0,get:function(){return Boolean(a[d.fullscreenEnabled])}}}),b?module.exports=f:window.screenfull=f}();
+
+    if (screenfull.enabled) {
+        screenfull.on('change', function () {
+            if (screenfull.isFullscreen) {
+                $('#fullscreen-button').addClass("exit");
+            } else {
+                $('#fullscreen-button').removeClass("exit");
+            }
+        });
+    }
+
+}

--- a/static/flow/views/fullscreen-widget.js
+++ b/static/flow/views/fullscreen-widget.js
@@ -3,17 +3,18 @@
 //
 var FullScreenWidget = function() {
 
-    //var fullscreenContainer = jQuery('<div>', {class:'fullscreen-container'} );
     var fullscreenContainer = jQuery('#fullscreen-widget');
     var fullscreenButton  = jQuery('<div>', {id:'fullscreen-button'} );
     fullscreenButton.appendTo(fullscreenContainer);
-    //fullscreenContainer.appendTo(menuAndContentHolder);
     var fullscreen = false;
     fullscreenButton.click(function(e) {
         if (screenfull.enabled) {
             screenfull.toggle();
         }
     });
+    //
+    // function to enter or exit fullscreen
+    //
     function requestFullScreen(element) {
         // Supports most browsers and their versions.
         var requestMethod = element.requestFullScreen || element.webkitRequestFullScreen || element.mozRequestFullScreen || element.msRequestFullScreen;

--- a/static/flow/views/fullscreen-widget.js
+++ b/static/flow/views/fullscreen-widget.js
@@ -12,30 +12,6 @@ var FullScreenWidget = function() {
             screenfull.toggle();
         }
     });
-    //
-    // function to enter or exit fullscreen
-    //
-    function requestFullScreen(element) {
-        // Supports most browsers and their versions.
-        var requestMethod = element.requestFullScreen || element.webkitRequestFullScreen || element.mozRequestFullScreen || element.msRequestFullScreen;
-
-        if (requestMethod) { // Native full screen.
-            requestMethod.call(element);
-        } else if (typeof window.ActiveXObject !== "undefined") { // Older IE.
-            var wscript = new ActiveXObject("WScript.Shell");
-            if (wscript !== null) {
-                wscript.SendKeys("{F11}");
-            }
-        }
-
-        fullscreen = !fullscreen;
-        if(fullscreen){
-            $('#fullscreen-button').addClass("exit");
-        }
-        else{
-            $('#fullscreen-button').removeClass("exit");
-        }
-    }
 
     /*!
     * screenfull

--- a/templates/flow-app.html
+++ b/templates/flow-app.html
@@ -78,7 +78,10 @@
     <script 
       src="/ext/flow-server/static/flow/views/admin-view.js">
     </script>
-
+    <script 
+      src="/ext/flow-server/static/flow/views/fullscreen-widget.js">
+    </script>
+	
 
 	<script src="/ext/flow-server/static/flow/ble-app.js"></script>
 	<script src="/ext/flow-server/static/flow/diagram.js"></script>
@@ -104,7 +107,7 @@
         };
     </script>
 {% endif %}
-
+	
 	<link rel="stylesheet" href="/ext/flow-server/static/flow/style.css">
 <title>Data Flow</title>
 </head>
@@ -122,7 +125,8 @@
 
 <div    id="admin-view" ></div>
 <div    id="program-editor-view" ></div>
-
+<div    id="fullscreen-widget"
+        class="fullscreen-container"></div>
 
 
 <script>
@@ -132,6 +136,7 @@ var g_controller = null;  // the currently selected controller
 var g_csrfToken = '{{ csrf_token() }}';
 var g_jsSim = false;
 var g_useCodap = {{ use_codap }};
+var g_fullscreen = {{ use_fullscreen }};
 var g_adminEnabled = false; //1.0
 var g_user                  = {{ flow_user|safe }};
 var g_rhizo_server_version  = '{{ rhizo_server_version }}';


### PR DESCRIPTION
Fullscreen is optionally shown via a URL parameter (hence the changes in ext.py, flow-app.js, and flow-app.html).  You'll also see some whitespace clean up in these modules which makes up a bulk of the diff.  SVG files and fullscreen implementation in fullscreen-widget was taken from existing implementation in SEPA app as per Sam's recommendation (and trying to ensure unified look of tools in CC apps).