### PR TITLE
program no longer requires a live sensor to have a sensor block

### DIFF
--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -562,27 +562,6 @@ var PiSelectorPanel = function(options) {
         }
 
         //
-        // Check that all sensor blocks can be mapped to physical sensors.
-        //
-        var unmapped = editor.getProgramEditorPanel().getUnmappedSensors();
-        if(unmapped.length > 0) {
-            var names = "";
-            for(var i = 0; i < unmapped.length; i++) {
-                if(i != 0) {
-                    names += ",";
-                }
-                names += " " + unmapped[i];
-            }
-            modalAlert({
-                title: 'Cannot Run Program',
-                message: "Error: The following blocks do not have available sensors on " + controller.name + ":" + names,
-                nextFunc: function() {
-                    updateProgramButtons(false, false, false);
-                }});
-            return;
-       }
-
-        //
         // Set name on program
         //
         var displayedName = jQuery('#program-editor-filename').val();


### PR DESCRIPTION
Request to eliminate rule that a pi *must* have a sensor of type n to run a program with a type n sensor block (so, for example, previously if a program included a light sensor, the pi had to have a light sensor attached to run).  This will eventually tie to the larger discussion of how we display data since this can, in theory, allow a user to collect a data sequence of null values (adds block that doesn't have an analogous physical sensor, attaches block to data storage block, runs program).  However, this can be addressed in a future dataview specific story.