### PR TITLE
159319537 activity feed update realtime

### DIFF
--- a/static/flow/views/landing-page-data-set-view.js
+++ b/static/flow/views/landing-page-data-set-view.js
@@ -84,7 +84,6 @@ var LandingPageDataSetView = function(options) {
                                 livedatablock.appendTo(liveDataHolder);
                                 // console.log("[DEBUG] Creating dataset item", items[i]);
                             }
-
                         }
                         else{
                             for(var i = 0; i < list.length; i++) {
@@ -113,6 +112,15 @@ var LandingPageDataSetView = function(options) {
 
                     if (recording.length == 0 && recorded.length == 0) {
                         addDatasetMessageToMenu(recordedDataHolder, "No available datasets");
+                    }
+
+                    if (recording.length) {
+                        // we found a currently recording dataset...
+                        // poll the server for pi status updates to allow analogous update of activity feed state
+                        // e.g., if pi is marked as "unavailable" in activity feed, update feed if pi comes back online
+                        var editor = getTopLevelView("program-editor-view");
+                        var piSelectorPanel = editor.getPiSelectorPanel();
+                        piSelectorPanel.restartLoadPiListTimer();
                     }
 
                     //resize the landing page view

--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -75,7 +75,7 @@ var PiSelectorPanel = function(options) {
             var potentialButton = $(potentialButtonId);
             var potentialStatusDiv = $(potentialStatusId);
             if(potentialButton.length && potentialStatusDiv.length){
-                if(!controller.online) {
+                if(controller.online) {
                     potentialButton.show();
                     potentialStatusDiv.hide();
                 }

--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -27,7 +27,7 @@ var PiSelectorPanel = function(options) {
 
     //check if sensor data is delayed or has stopped updating
     var loadPiListTimer;
-    var loadPiListTimerInterval = 10000; //30 seconds
+    var loadPiListTimerInterval = 30000; //30 seconds
 
     //
     // Devices: list of available pis and refresh button
@@ -38,10 +38,10 @@ var PiSelectorPanel = function(options) {
     //
     //function to determine if a pi is online or offline
     //
-    this.isPiOffline = function(piName){
+    this.isPiOffline = function(piName) {
         var retval = false;
         //if we have no list of pis chances are we haven't received a response from the server
-        if(this.availableControllers.length == 0){
+        if (this.availableControllers.length == 0) {
             return retval;
         }
         //what is the status of pi?
@@ -64,7 +64,7 @@ var PiSelectorPanel = function(options) {
     // update any running program blocks on landing page based on online/offline pis
     //
     var updateActivityFeed = function (){
-        if(this.availableControllers.length == 0){
+        if (this.availableControllers.length == 0) {
             return;
         }
         //find any running program blocks
@@ -74,20 +74,18 @@ var PiSelectorPanel = function(options) {
             var potentialStatusId = "#liveDataStatusDiv" + controller.name;
             var potentialButton = $(potentialButtonId);
             var potentialStatusDiv = $(potentialStatusId);
-            if(potentialButton.length && potentialStatusDiv.length){
-                if(controller.online) {
+            if (potentialButton.length && potentialStatusDiv.length) {
+                if (controller.online) {
                     potentialButton.show();
                     potentialStatusDiv.hide();
                 }
-                else{
+                else {
                     potentialButton.hide();
                     potentialStatusDiv.show();
                 }
             }
         }
-        restartLoadPiListTimer(loadPiListTimerInterval);
     }
-
 
     //
     // set default state of topbar program controls UI
@@ -99,7 +97,6 @@ var PiSelectorPanel = function(options) {
         _this.currentlyRecording = false;
         _this.selectedController = null;
     }
-
 
     //
     // AJAX call and handler for listing Pis.
@@ -714,44 +711,26 @@ var PiSelectorPanel = function(options) {
     }
 
     //
-    // is the activity feed in a state where it contains a program?
+    // timer fired, update pi list
     //
-    function activityFeedContainsProgram() {
-        if ($(".live-data-item-holder").length) {
-            return true;
-        }
-        else {
-            return false;
-        }
-    }
-
-    //
-    // timer fired, do we need a new list of pis?
-    //
-    function checkUpdatePiList() {
+    function updatePiList() {
         clearTimeout(loadPiListTimer);
-
-        // refresh list if we have an active program in the activity feed
-        // in the future, other actions might trigger refresh of list
-        var updateActivityFeedPrograms = activityFeedContainsProgram();
-        if (updateActivityFeedPrograms){
-            _this.loadPiList(false);
-        }
-        else {
-            restartLoadPiListTimer(loadPiListTimerInterval);
-        }
+        _this.loadPiList(false);
+        restartLoadPiListTimer(loadPiListTimerInterval);
     }
+
     //
     // restart timer to determine if we need to get an updated list of pis
     //
-    function restartLoadPiListTimer(timeInterval){
+    this.restartLoadPiListTimer = function() {
         clearTimeout(loadPiListTimer);
-        loadPiListTimer = setTimeout(checkUpdatePiList, timeInterval);
+        loadPiListTimer = setTimeout(updatePiList, loadPiListTimerInterval);
     }
+
     //
     // stop timer that determines if we need to get an updated list of pis
     //
-    function disableLoadPiListTimer(){
+    this.disableLoadPiListTimer = function() {
         clearTimeout(loadPiListTimer);
     }
 

--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -717,7 +717,7 @@ var PiSelectorPanel = function(options) {
     // is the activity feed in a state where it contains a program?
     //
     function activityFeedContainsProgram() {
-        if ($("live-data-item-holder").length) {
+        if ($(".live-data-item-holder").length) {
             return true;
         }
         else {

--- a/static/flow/views/program-editor-view.js
+++ b/static/flow/views/program-editor-view.js
@@ -112,18 +112,18 @@ var ProgramEditorView = function(options) {
                 if(response.success) {
                     if(typeof completionCallback === "function") {
                         completionCallback(true);
-					}
+                    }
                 } else {
                     if(typeof completionCallback === "function") {
                         completionCallback(false);
-					}
+                    }
                 }
             },
             error: function(data) {
                 console.log("[ERROR] Save error", data);
                 if(typeof completionCallback === "function") {
                     completionCallback(false);
-				}
+                }
             },
         });
 
@@ -291,6 +291,7 @@ var ProgramEditorView = function(options) {
     // Load program from spec stored in dataset metadata
     //
     base.loadProgramFromSpec = function(params) {
+
         // console.log("[DEBUG] ProgramEditorView loadProgramFromSpec()", params);
         programloaded = true;
 
@@ -301,6 +302,8 @@ var ProgramEditorView = function(options) {
         var nameWidget      = jQuery('#program-editor-filename');
 
         nameWidget.val(displayedName);
+
+        piSelectorPanel.disableLoadPiListTimer();
 
         piSelectorPanel.resetStateOnProgramLoad();
         piSelectorPanel.resetPiSelectionState();
@@ -323,6 +326,8 @@ var ProgramEditorView = function(options) {
         var nameWidget      = jQuery('#program-editor-filename');
 
         nameWidget.val('');
+
+        piSelectorPanel.disableLoadPiListTimer();
 
         piSelectorPanel.setProgramControlsToNeutral();
         piSelectorPanel.loadPiList(true);


### PR DESCRIPTION
When an activity feed block is created that contains a running program, start a timer that polls the server to obtain pi statuses.  If a pi status has changed, update the UI to reflect this change (e.g., if UI says Pi is offline, but server reports that pi is now back online, update UI so user knows state of Pi).  When we leave the landing page/activity feed, stop polling the server for pi status.