### PR TITLE
update blocks after undo and load

### DIFF
--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -162,12 +162,12 @@ var ProgramEditorPanel = function(options) {
 
         _this.displayAllConnections();
 
+        _this.updateAllBlocks();
+        
         // resave program, but do not resave the state
         _this.autoSaveProgram(false, false);
 
         _this.lastChangeMoveBlock = false;
-
-        _this.updateAllBlocks();
     };
 
     // bind the undo key when we init, be sure only to call once

--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -115,6 +115,8 @@ var ProgramEditorPanel = function(options) {
 
         this.displayAllConnections();
 
+        this.updateAllBlocks();
+
         this.lastChangeMoveBlock = false;
         storeProgramState(false);
     };
@@ -164,6 +166,8 @@ var ProgramEditorPanel = function(options) {
         _this.autoSaveProgram(false, false);
 
         _this.lastChangeMoveBlock = false;
+
+        _this.updateAllBlocks();
     };
 
     // bind the undo key when we init, be sure only to call once


### PR DESCRIPTION
Add calls to update blocks after ctrl+z undo and after program load.  Math blocks (such as plus, minus, etc.) were not updating when they had value inputs.  Instead showed invalid string "..."
[#159514952]