### PR TITLE
Added autoload-config.py to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 *.pyc
+autoload-config.py


### PR DESCRIPTION
This is to support a Dockerized version of the rhizo-server that will
autoload extension config files into the main rhizo app config.

This is currently used to set the three portal sso config variables:

FLOW_PORTAL_SITE = 'https://learn.concord.org'
FLOW_PORTAL_SSO_CLIENT_ID = 'dataflow'
FLOW_PORTAL_SSO_CLIENT_SECRET = 'REPLACE-WITH-REAL-SECRET'