### PR TITLE
Fixed generation of filenames [#159953929]

### DIFF
--- a/static/flow/flow-util.js
+++ b/static/flow/flow-util.js
@@ -112,6 +112,14 @@ Util.convertDateTimeStringToHumanReadable = function(dateTimeStr) {
     var hour = dateTimeStr.substring(9, 11);
     var min = dateTimeStr.substring(11, 13);
 
+    var dayNum = parseInt(day, 10);
+    var hourNum = parseInt(hour, 10);
+    var minNum = parseInt(min, 10);
+
+    if (isNaN(dayNum) || isNaN(hourNum) || isNaN(minNum)) {
+        return "Invalid date in filename";
+    }
+
     if (month == "01")
         month = "January";
     else if (month == "02")
@@ -136,8 +144,6 @@ Util.convertDateTimeStringToHumanReadable = function(dateTimeStr) {
         month = "November";
     else if (month == "12")
         month = "December";
-    var dayNum = parseInt(day, 10);
-    var hourNum = parseInt(hour, 10);
     var ampm = "AM";
     if (hourNum == 0) {
         hourNum = 12;
@@ -149,7 +155,6 @@ Util.convertDateTimeStringToHumanReadable = function(dateTimeStr) {
         hourNum -= 12;
         ampm = "PM";
     }
-    var minNum = parseInt(min, 10);
     if (min < 10) {
         minNum = "0" + minNum;
     }

--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -234,11 +234,11 @@ var ProgramEditorPanel = function(options) {
         };
 
         var potentialName = prefixStr + year;
-        potentialName += this._formatDatePart(potentialName, month);
-        potentialName += this._formatDatePart(potentialName, day) + "_";;
-        potentialName += this._formatDatePart(potentialName, hour);
-        potentialName += this._formatDatePart(potentialName, min);
-        potentialName += this._formatDatePart(potentialName, sec);
+        potentialName = this._formatDatePart(potentialName, month);
+        potentialName = this._formatDatePart(potentialName, day) + "_";
+        potentialName = this._formatDatePart(potentialName, hour);
+        potentialName = this._formatDatePart(potentialName, min);
+        potentialName = this._formatDatePart(potentialName, sec);
 
         return potentialName;
     };


### PR DESCRIPTION
Reverted recent code change that appended instead of replaced text while generating filenames causing very long invalid filenames.

Also added check in filename parser for the tooltips to return an error string if it can't be parsed instead of returning NaN in the string.