### PR TITLE
Sort rendering of graphs in the dataset view

### DIFF
--- a/static/external/manyplot.js
+++ b/static/external/manyplot.js
@@ -63,7 +63,8 @@ let _plotOptions = {
   TimeColor: "#000",
   CaptionFontSize: 12,
   SmallFontSize: 10,
-  XAxisLabelPadding: 5
+  XAxisLabelPadding: 5,
+  SortSequences: true
 };
 
 function createPlotHandler(canvas, multiFrame, options) {
@@ -223,7 +224,7 @@ function createPlotter( canvas, multiFrame, options ) {
 
     // set data to use for plotting; updates plot bounds from data
     plotter.setData = function( dataPairs ) {
-        this.dataPairs = dataPairs;
+        this.dataPairs = plotter.opts.SortSequences ? this.sortData(dataPairs) : dataPairs;
         // Frame count
         var frameCount = multiFrame ? this.dataPairs.length : 1;
         if(frameCount < 1){
@@ -237,6 +238,25 @@ function createPlotter( canvas, multiFrame, options ) {
         if(this.plotMode === "scatter"){
             this.autoBounds();
         }
+    };
+
+    plotter.sortData = function (dataPairs) {
+        dataPairs.sort((a, b) => {
+            // Sanity check that the pairs contain data
+            if (a.yData && a.yData.name && b.yData && b.yData.name) {
+                var nameA = a.yData.name.toUpperCase(),
+                    nameB = b.yData.name.toUpperCase();
+                if (nameA < nameB) {
+                    return -1;
+                }
+                if (nameA > nameB) {
+                    return 1;
+                }
+            }
+            // names must be equal
+            return 0;
+        });
+        return dataPairs;
     };
 
     // fix(soon): refactor

--- a/static/flow/views/data-set-view.js
+++ b/static/flow/views/data-set-view.js
@@ -204,7 +204,8 @@ var DataSetView = function(options) {
           AxisLine: "#333",
           AxisLabel: "#333",
           CaptionFontSize: 12,
-          SmallFontSize: 10
+          SmallFontSize: 10,
+          SortSequences: true // always display datasets with alphabetic sorting for consistency
         };
         // Manyplot supports overlaying multiple data sets on the same plot. Currently we show individual plots.
         // To overlay multiple plots we'd need to use different line colors for each data series and offset y-axis labels


### PR DESCRIPTION
This should ensure that plots always render in alphabetical order, regardless of the order of the plot pairs. Manyplot can be initialized with multiple data sequences per set and can choose to display as individual graphs or as stacked graphs on the same plot. Since we don't use the multiple data sequences on the same graph approach at the moment, the requirement is for consistency in rendering the datasets when re-opening the results. I've used a very simple alphabetic sort for the name of the sensor for this.

Added configuration option to disable this feature if required. This should also ensure consistent rendering whenever the plot data is updated with new sequences. 