### PR TITLE
Fix CODAP export bug

### DIFF
--- a/static/flow/style.css
+++ b/static/flow/style.css
@@ -480,7 +480,9 @@
     width: 200px;
     margin-left: 30px;
 }
-
+#data-set-canvas {
+    padding-bottom: 10px;
+}
 /*
 * — Activity Feed —
 */

--- a/static/flow/style.css
+++ b/static/flow/style.css
@@ -950,10 +950,10 @@ button.filter {
     font-style: normal;
 }
 
-div.smoothie-chart-tooltip {
-  background: #ccc;
-  padding: 1em;
-  color: #333;
-  pointer-events: none;
-  border-radius: 8px;
+#version-info{
+    position: fixed;
+    bottom:2px;
+    left:5px;
+    font-size: 0.6em;
+    color: #aaa;
 }

--- a/static/flow/views/data-set-view.js
+++ b/static/flow/views/data-set-view.js
@@ -204,7 +204,8 @@ var DataSetView = function(options) {
           AxisLine: "#333",
           AxisLabel: "#333",
           CaptionFontSize: 12,
-          SmallFontSize: 10
+          SmallFontSize: 10,
+          SortSequences: true // always display datasets with alphabetic sorting for consistency
         };
         // Manyplot supports overlaying multiple data sets on the same plot. Currently we show individual plots.
         // To overlay multiple plots we'd need to use different line colors for each data series and offset y-axis labels
@@ -562,8 +563,15 @@ var DataSetView = function(options) {
         var timeThresh = 0.4;  // seconds
         // Here we see the presentation layer grabbing data from a graphing library
         // TODO: Refactor! The graphing library should not be a data store.
-        var dataPairs = base.m_plotHandler.plotter.dataPairs;
-        if (dataPairs.length && dataPairs[0].xData.data.length) {
+        var dataPairs = [];
+        // Only export data sequences that have data pairs
+        base.m_plotHandler.plotter.dataPairs.forEach(dataPair => {
+            if (dataPair.xData.data.length > 0) {
+                dataPairs.push(dataPair);
+            }
+        });
+
+        if (dataPairs.length > 0) {
             // Set collection attributes based on sequence data
             var attrs = [{name: 'seconds', type: 'numeric', precision: 2}, {name: 'timestamp', type: 'date'}];
             for (var i = 0; i < dataPairs.length; i++) {

--- a/static/flow/views/data-set-view.js
+++ b/static/flow/views/data-set-view.js
@@ -25,9 +25,9 @@ var DataSetView = function(options) {
 
     PLOTTER_PADDING_VERTICAL    = 80;   // px
     RIGHT_PANEL_WIDTH           = 200;  // px
-    VERTICAL_MARGIN             = 80;   // px
+    VERTICAL_MARGIN             = 100;   // px
     HORIZONTAL_MARGIN           = 100;  // px
-    PLOTTER_MARGIN_BOTTOM       = 94; // px
+    PLOTTER_MARGIN_BOTTOM       = 100; // px
 
     var datasetTopbar = $('<div>', { class: 'dataset-info-topbar' });
     var datasetName = $('<div>', { class: 'dataset-info-text dataset-info-text-title' }).text('Dataset Name: ');
@@ -454,7 +454,6 @@ var DataSetView = function(options) {
         var dataPairs = base.m_plotHandler.plotter.dataPairs;
         for (var i = 0; i < dataPairs.length; i++) {
             var d = dataPairs[i];
-            console.log("[DEBUG] findDataPair checking", d.yData.name, sequenceName);
             if (d.yData.name === sequenceName) {
                 dataPair = d;
                 break;
@@ -510,7 +509,7 @@ var DataSetView = function(options) {
         sequenceCount = 0;
 
         for (var i = 0; i < sequences.length; i++) {
-            if(sequences[i].name!="metadata"){
+            if (sequences[i].name != "metadata") {
                 sequenceCount++;
                 base.requestServerSequenceData(sequences[i].name, {
                     count: 100000,
@@ -564,16 +563,17 @@ var DataSetView = function(options) {
         // Here we see the presentation layer grabbing data from a graphing library
         // TODO: Refactor! The graphing library should not be a data store.
         var dataPairs = [];
-        // Only export data sequences that have data pairs
+        var includeEmptyDataSequences = true
         base.m_plotHandler.plotter.dataPairs.forEach(dataPair => {
-            if (dataPair.xData.data.length > 0) {
+            // Can filter out empty data sequences by only adding dataPairs with data
+            if (includeEmptyDataSequences || dataPair.xData.data.length > 0) {
                 dataPairs.push(dataPair);
             }
         });
 
         if (dataPairs.length > 0) {
             // Set collection attributes based on sequence data
-            var attrs = [{name: 'seconds', type: 'numeric', precision: 2}, {name: 'timestamp', type: 'date'}];
+            var attrs = [{ name: 'seconds', type: 'numeric', precision: 2 }, { name: 'timestamp', type: 'date' }];
             for (var i = 0; i < dataPairs.length; i++) {
                 attrs.push({
                     name: dataPairs[i].yData.name,
@@ -584,7 +584,7 @@ var DataSetView = function(options) {
 
             CodapTest.prepCollection(
                 attrs,
-                function() {
+                function () {
                     // Get data for quick reference
                     var xs = [];
                     var ys = [];
@@ -682,22 +682,28 @@ var DataSetView = function(options) {
                     //
                     codapInterface.sendRequest(
                         {
-                            action:     "create",
-                            resource:   "component",
-                            values:     {   type:           "caseTable",
-                                            name:           "explore_flow_data",
-                                            title:          "Explore Data in CODAP",
-                                            dimensions:     {   width:  700,
-                                                                height: 500 },
-                                            dataContext:    "Flow_Data"
-                                        }
+                            action: "create",
+                            resource: "component",
+                            values: {
+                                type: "caseTable",
+                                name: "explore_flow_data",
+                                title: "Explore Data in CODAP",
+                                dimensions: {
+                                    width: 700,
+                                    height: 500
+                                },
+                                dataContext: "Flow_Data"
+                            }
                         },
-                        function(iResult, iRequest) {
+                        function (iResult, iRequest) {
                             debug("Opened case table", iResult);
                         }
                     );
                 }
             );
+        } else {
+            // no data pairs have data, so we have nothing to select or export to CODAP
+            console.error("No data selected to be sent to CODAP");
         }
     }
 

--- a/templates/flow-app.html
+++ b/templates/flow-app.html
@@ -147,7 +147,7 @@
 <div    id="program-editor-view" ></div>
 <div    id="fullscreen-widget"
         class="fullscreen-container"></div>
-
+<div    id="version-info">{{ flow_server_version }}</div>
 
 <script>
 


### PR DESCRIPTION
When a dataset is being viewed, interval selection would fail if any sequence in the set was empty. This fix should still allow interval selection for valid data sequences with pairs of data, and hand only those sequences to CODAP for analysis.