### PR TITLE
Ensure sensor and timer values are null when loading a program

### DIFF
--- a/static/flow/diagram.js
+++ b/static/flow/diagram.js
@@ -232,13 +232,7 @@ function createFlowBlock(blockSpec) {
         }
         var value = this.value;
         //strip out values from sensors and timers, these should NOT be saved
-        if (this.type == "temperature" ||
-            this.type == "humidity" ||
-            this.type == "light" ||
-            this.type == "soilmoisture" ||
-            this.type == "CO2" ||
-            this.type == "O2" ||
-            this.type == "timer")
+        if (DEVICE_BLOCKS.indexOf(this.type) > -1 || this.type == "timer")
             value = null;
         return {
             id: this.id,

--- a/static/flow/diagram.js
+++ b/static/flow/diagram.js
@@ -231,13 +231,14 @@ function createFlowBlock(blockSpec) {
             }
         }
         var value = this.value;
-        //strip out values from sensors, these should NOT be saved
+        //strip out values from sensors and timers, these should NOT be saved
         if (this.type == "temperature" ||
             this.type == "humidity" ||
             this.type == "light" ||
             this.type == "soilmoisture" ||
             this.type == "CO2" ||
-            this.type == "O2")
+            this.type == "O2" ||
+            this.type == "timer")
             value = null;
         return {
             id: this.id,

--- a/static/flow/views/program-editor-panel.js
+++ b/static/flow/views/program-editor-panel.js
@@ -97,6 +97,13 @@ var ProgramEditorPanel = function(options) {
             // then it might not have a valid file name
             programSpec.name = this.createDateTimeName("program_");
         }
+        // null values from sensors and timers in case they were erroneously saved
+        for (var specBlocks = 0; specBlocks < programSpec.blocks.length; specBlocks++) {
+            var specBlockType = programSpec.blocks[specBlocks].type;
+            if (this.isDeviceBlock(specBlockType) || specBlockType==="timer") {
+                 programSpec.blocks[specBlocks].value = null;
+            }
+        }
 
         this.undisplayAllBlocks();
 


### PR DESCRIPTION
Ensure sensor and timer values are null when loading a program.  At present we are forcing sensor values to null when saving a program.  However, there are some older style programs that were saved with sensor values in the program spec (value should always be null to prevent displaying erroneous sensor value). Expand protection to handle when opening old programs.
