### PR TITLE
160738755 sensor values show when none selected

### DIFF
--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -341,21 +341,6 @@ var PiSelectorPanel = function(options) {
     }
 
     //
-    // Select no pis from the list
-    //
-    var selectNoPi = function() {
-        // set state of run program button
-        updateProgramButtons(true, false, false);
-
-        // stop listening for messages from any existing Pi
-        clearSubscriptions();
-        removeMessageHandlers();
-
-        // handle unselection of pi, clear program editor state
-        editor.getProgramEditorPanel().piUnselected();
-
-    }
-    //
     // Change editor state to running program
     //
     var enterRunProgramState = function() {

--- a/static/flow/views/pi-selector-panel.js
+++ b/static/flow/views/pi-selector-panel.js
@@ -52,6 +52,12 @@ var PiSelectorPanel = function(options) {
             callback(!!snapshot.val());
         };
     };
+    this.firebaseControllerReset = function () {
+        if (firebaseControllerRef) {
+            firebaseControllerRef.off("value", handleFirebaseControllerValueChange);
+            firebaseControllerRef = null;
+        }
+    };
 
     //
     // Determine if a pi is online or offline
@@ -273,8 +279,8 @@ var PiSelectorPanel = function(options) {
             }
         }
         if (!foundPi) {
-            deviceSelectedText.text("none");
-            selectNoPi();
+            firebaseControllerReset();
+            resetPiSelectionState();
         }
     }
 
@@ -291,7 +297,6 @@ var PiSelectorPanel = function(options) {
     // Need to call when we open a program, create a new program
     //
     this.resetPiSelectionState = function() {
-
         // select none from the menu
         // not needed if we regen the list
         deviceSelectedText.text("none");
@@ -301,6 +306,9 @@ var PiSelectorPanel = function(options) {
         // stop listening for messages from any existing Pi
         clearSubscriptions();
         removeMessageHandlers();
+
+        // handle unselection of pi, clear program editor state
+        editor.getProgramEditorPanel().piUnselected();
     }
 
     //
@@ -443,14 +451,9 @@ var PiSelectorPanel = function(options) {
             sendSensorData.execute();
         };
 
-        if (firebaseControllerRef) {
-            firebaseControllerRef.off("value", handleFirebaseControllerValueChange);
-            firebaseControllerRef = null;
-        }
-
+        firebaseControllerReset();
         if (deviceName == "none") {
-            // invalid index, none was probably selected
-            selectNoPi();
+            resetPiSelectionState();
             return;
         }
         if (!_this.currentlyRecording) {

--- a/static/flow/views/program-editor-view.js
+++ b/static/flow/views/program-editor-view.js
@@ -304,6 +304,7 @@ var ProgramEditorView = function(options) {
         piSelectorPanel.disableLoadPiListTimer();
 
         piSelectorPanel.resetStateOnProgramLoad();
+        piSelectorPanel.firebaseControllerReset();
         piSelectorPanel.resetPiSelectionState();
 
         //
@@ -330,6 +331,7 @@ var ProgramEditorView = function(options) {
         piSelectorPanel.setProgramControlsToNeutral();
         piSelectorPanel.loadPiList(true);
         piSelectorPanel.resetStateOnProgramLoad();
+        piSelectorPanel.firebaseControllerReset();
         piSelectorPanel.resetPiSelectionState();
 
         //


### PR DESCRIPTION
Prevent sensor values from appearing in blocks when no Pi is selected ("none" in the Pi selection list in the topbar).  Firebase connection was only previously stopped when user explicitly selected "none" from the Pi selection list.  However, Pi selection is also set to "none" when loading a new program.  Changes stop Firebase sensor updates from controller (Pi) when we load a new program to ensure that incorrect values from previously selected Pi are not shown in flow blocks.
- add `firebaseControllerReset()` function which we call when we set the Pi selection to "none".  This can be done manually by the user but also happens when a new program is loaded or we try to reselect a Pi that is no longer available (and hence set "none" for Pi selected)
- consolidate action when "none" is selected into `resetPiSelectionState()` function and remove obsolete `selectNoPi()` function