### PR TITLE
change firebase init delay

### DIFF
--- a/ext.py
+++ b/ext.py
@@ -114,7 +114,7 @@ def handle_socket_connected(ws_conn, socket_sender):
         gevent.spawn(send_delayed_firebase_init, ws_conn, socket_sender, init_message)
 
 def send_delayed_firebase_init(ws_conn, socket_sender, init_message):
-    gevent.sleep(1)
+    gevent.sleep(6) # testing on Pi zero shows this needs to be much longer than 1 sec 
     socket_sender.send_message(ws_conn, 'flow_server::firebase_init', init_message)
 
 # display the data flow app (a single page app)


### PR DESCRIPTION
Change delay from 1 sec to 6 sec so Pi Zeros have time to boot up before we tell them to connect to Firebase.  6 seconds was the requested time from Lisa based on her tests with Pi Zeros (I don't have one for testing so I'm relying on her to provide an acceptable delay time).